### PR TITLE
Added send method that takes Data

### DIFF
--- a/Sources/APNS/Request+APNS.swift
+++ b/Sources/APNS/Request+APNS.swift
@@ -46,36 +46,6 @@ extension Request.APNS: APNSwiftClient {
         }
     }
 
-    public func send(
-        rawBytes payload: ByteBuffer,
-        pushType: APNSwiftConnection.PushType,
-        to deviceTokens: [String],
-        expiration: Date?,
-        priority: Int?,
-        collapseIdentifier: String?,
-        topic: String?,
-        logger: Logger?
-    ) -> EventLoopFuture<Void> {
-        self.request.application.apns.pool.withConnection(
-            logger: logger,
-            on: self.eventLoop
-        ) { conn in
-            deviceTokens.map { deviceToken in
-                conn.send(
-                    rawBytes: payload,
-                    pushType: pushType,
-                    to: deviceToken,
-                    expiration: expiration,
-                    priority: priority,
-                    collapseIdentifier: collapseIdentifier,
-                    topic: topic,
-                    logger: logger
-                )
-            }
-            .flatten(on: self.request.eventLoop)
-        }
-    }
-
     public func send<T: Collection>(
         rawData payload: T,
         pushType: APNSwiftConnection.PushType,
@@ -91,24 +61,4 @@ extension Request.APNS: APNSwiftClient {
 
         return send(rawBytes: rawBytes, pushType: pushType, to: deviceToken, expiration: expiration, priority: priority, collapseIdentifier: collapseIdentifier, topic: topic, logger: logger)
     }
-
-    public func send<T: Collection>(
-        rawData payload: T,
-        pushType: APNSwiftConnection.PushType,
-        to deviceTokens: [String],
-        expiration: Date?,
-        priority: Int?,
-        collapseIdentifier: String?,
-        topic: String?,
-        logger: Logger?
-    ) -> EventLoopFuture<Void> where T.Element == UInt8 {
-        var rawBytes = ByteBufferAllocator().buffer(capacity: payload.count)
-        rawBytes.writeBytes(payload)
-
-        return deviceTokens.map {
-            send(rawBytes: rawBytes, pushType: pushType, to: $0, expiration: expiration, priority: priority, collapseIdentifier: collapseIdentifier, topic: topic, logger: logger)
-        }
-        .flatten(on: request.eventLoop)
-    }
-
 }

--- a/Sources/APNS/Request+APNS.swift
+++ b/Sources/APNS/Request+APNS.swift
@@ -45,4 +45,70 @@ extension Request.APNS: APNSwiftClient {
             )
         }
     }
+
+    public func send(
+        rawBytes payload: ByteBuffer,
+        pushType: APNSwiftConnection.PushType,
+        to deviceTokens: [String],
+        expiration: Date?,
+        priority: Int?,
+        collapseIdentifier: String?,
+        topic: String?,
+        logger: Logger?
+    ) -> EventLoopFuture<Void> {
+        self.request.application.apns.pool.withConnection(
+            logger: logger,
+            on: self.eventLoop
+        ) { conn in
+            deviceTokens.map { deviceToken in
+                conn.send(
+                    rawBytes: payload,
+                    pushType: pushType,
+                    to: deviceToken,
+                    expiration: expiration,
+                    priority: priority,
+                    collapseIdentifier: collapseIdentifier,
+                    topic: topic,
+                    logger: logger
+                )
+            }
+            .flatten(on: self.request.eventLoop)
+        }
+    }
+
+    public func send<T: Collection>(
+        rawData payload: T,
+        pushType: APNSwiftConnection.PushType,
+        to deviceToken: String,
+        expiration: Date?,
+        priority: Int?,
+        collapseIdentifier: String?,
+        topic: String?,
+        logger: Logger?
+    ) -> EventLoopFuture<Void> where T.Element == UInt8 {
+        var rawBytes = ByteBufferAllocator().buffer(capacity: payload.count)
+        rawBytes.writeBytes(payload)
+
+        return send(rawBytes: rawBytes, pushType: pushType, to: deviceToken, expiration: expiration, priority: priority, collapseIdentifier: collapseIdentifier, topic: topic, logger: logger)
+    }
+
+    public func send<T: Collection>(
+        rawData payload: T,
+        pushType: APNSwiftConnection.PushType,
+        to deviceTokens: [String],
+        expiration: Date?,
+        priority: Int?,
+        collapseIdentifier: String?,
+        topic: String?,
+        logger: Logger?
+    ) -> EventLoopFuture<Void> where T.Element == UInt8 {
+        var rawBytes = ByteBufferAllocator().buffer(capacity: payload.count)
+        rawBytes.writeBytes(payload)
+
+        return deviceTokens.map {
+            send(rawBytes: rawBytes, pushType: pushType, to: $0, expiration: expiration, priority: priority, collapseIdentifier: collapseIdentifier, topic: topic, logger: logger)
+        }
+        .flatten(on: request.eventLoop)
+    }
+
 }


### PR DESCRIPTION
This closes issue #7  if accepted.  It implements the requested versions that will take a `Data` element and also adds to helper methods that will take an array of tokens instead of a single one.  It's not that uncommon to send a bunch of tokens the exact same message, so this seems helpful.  Especially would get used for people doing PassKit.
