### PR TITLE
Renamed package and structs to APNs as per Apple naming

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,14 +7,14 @@ let package = Package(
        .macOS(.v10_14)
     ],
     products: [
-        .library(name: "APNS", targets: ["APNS"]),
+        .library(name: "APNs", targets: ["APNs"]),
     ],
     dependencies: [
         .package(url: "https://github.com/kylebrowning/APNSwift.git", from: "1.7.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.2.1"),
     ],
     targets: [
-        .target(name: "APNS", dependencies: ["APNSwift", "Vapor"]),
-        .testTarget(name: "APNSTests", dependencies: ["APNS", "XCTVapor"]),
+        .target(name: "APNs", dependencies: ["APNSwift", "Vapor"]),
+        .testTarget(name: "APNsTests", dependencies: ["APNs", "XCTVapor"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# APNS
+# APN
 
 Helpful extensions and abstractions for using [`APNSwift`](http://github.com/kylebrowning/APNSwift.git)

--- a/Sources/APNS/APNsConnectionSource.swift
+++ b/Sources/APNS/APNsConnectionSource.swift
@@ -1,7 +1,7 @@
 import AsyncKit
 import Logging
 
-public final class APNSConnectionSource: ConnectionPoolSource {
+public final class APNsConnectionSource: ConnectionPoolSource {
     private let configuration: APNSwiftConfiguration
 
     public init(configuration: APNSwiftConfiguration) {

--- a/Sources/APNS/Application+APNS.swift
+++ b/Sources/APNS/Application+APNS.swift
@@ -1,11 +1,11 @@
 import Vapor
 
 extension Application {
-    public var apns: APNS {
+    public var apns: APNs {
         .init(application: self)
     }
 
-    public struct APNS {
+    public struct APNs {
         struct ConfigurationKey: StorageKey {
             typealias Value = APNSwiftConfiguration
         }
@@ -21,10 +21,10 @@ extension Application {
 
 
         struct PoolKey: StorageKey, LockKey {
-            typealias Value = EventLoopGroupConnectionPool<APNSConnectionSource>
+            typealias Value = EventLoopGroupConnectionPool<APNsConnectionSource>
         }
 
-        internal var pool: EventLoopGroupConnectionPool<APNSConnectionSource> {
+        internal var pool: EventLoopGroupConnectionPool<APNsConnectionSource> {
             if let existing = self.application.storage[PoolKey.self] {
                 return existing
             } else {
@@ -32,10 +32,10 @@ extension Application {
                 lock.lock()
                 defer { lock.unlock() }
                 guard let configuration = self.configuration else {
-                    fatalError("APNS not configured. Use app.apns.configuration = ...")
+                    fatalError("APNs not configured. Use app.apns.configuration = ...")
                 }
                 let new = EventLoopGroupConnectionPool(
-                    source: APNSConnectionSource(configuration: configuration),
+                    source: APNsConnectionSource(configuration: configuration),
                     maxConnectionsPerEventLoop: 1,
                     logger: self.application.logger,
                     on: self.application.eventLoopGroup

--- a/Sources/APNS/Request+APNS.swift
+++ b/Sources/APNS/Request+APNS.swift
@@ -1,16 +1,16 @@
 import Vapor
 
 extension Request {
-    public var apns: APNS {
+    public var apns: APNs {
         .init(request: self)
     }
 
-    public struct APNS {
+    public struct APNs {
         let request: Request
     }
 }
 
-extension Request.APNS: APNSwiftClient {
+extension Request.APNs: APNSwiftClient {
     public var logger: Logger? {
         self.request.logger
     }

--- a/Tests/APNSTests/APNsTests.swift
+++ b/Tests/APNSTests/APNsTests.swift
@@ -1,7 +1,7 @@
-import APNS
+import APNs
 import XCTVapor
 
-class APNSTests: XCTestCase {
+class APNsTests: XCTestCase {
     func testApplication() throws {
         let app = Application(.testing)
         defer { app.shutdown() }


### PR DESCRIPTION
It's "Apple Push Notification services", i.e. APNs.  It's a nit, I know, but this just names the targets and classes to the proper capitalization.