### PR TITLE
Fix APNSwiftConnection.isClosed

### DIFF
--- a/Sources/APNS/APNSConnectionSource.swift
+++ b/Sources/APNS/APNSConnectionSource.swift
@@ -21,6 +21,6 @@ extension APNSwiftConnection: ConnectionPoolItem {
     }
 
     public var isClosed: Bool {
-        self.channel.isActive
+        !self.channel.isActive
     }
 }


### PR DESCRIPTION
`APNSwiftConnection.isClosed` now correctly returns `false` if the channel is still active. Fixes #11.