### PR TITLE
Beta 3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,14 +4,14 @@ import PackageDescription
 let package = Package(
     name: "apns",
     platforms: [
-       .macOS(.v10_14)
+       .macOS(.v10_15)
     ],
     products: [
         .library(name: "APNS", targets: ["APNS"]),
     ],
     dependencies: [
         .package(url: "https://github.com/kylebrowning/APNSwift.git", from: "1.7.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.2.1"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.4"),
     ],
     targets: [
         .target(name: "APNS", dependencies: ["APNSwift", "Vapor"]),


### PR DESCRIPTION
- Match Vapor's new minimum OS requirement
- Bump minimum required version of Vapor
- Major beta server due to compatibility break of new minimum OS requirement. There are no actual changes to this driver or to the underlying APNS implementation.