### PR TITLE
Fix for infinite loop

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "APNS", targets: ["APNS"]),
     ],
     dependencies: [
-        .package(name: "apnswift", url: "https://github.com/kylebrowning/APNSwift.git", from: "2.1.0"),
+        .package(name: "apnswift", url: "https://github.com/kylebrowning/APNSwift.git", from: "2.2.0"),
         .package(name: "vapor", url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Fix for https://github.com/kylebrowning/APNSwift/issues/100

When using the code below with `.package(url: "https://github.com/vapor/apns.git", from: "1.0.0"),` and the `master` branch of `kylebrowning/APNSwift`.
It make an infinite recursion.

```swift
func routes(_ app: Application) throws {
    app.get { req in
        return "It works!"
    }

    app.get("hello") { req -> String in
        return "Hello, world!"
    }
  
  app.get("test") { req in
    req.apns.send(
      .init(title: "Hello", subtitle: "This is a test from vapor/apns"),
      to: "971de327b678069dab8f4ddb6aaa833416a27c98234eb118f65b9cd0e281573f"
    ).map { "sent" }
  }
}
```

Because in `Application+APNS.swift` in `extension Application.APNS: APNSwiftClient` it called the bad send line 78 `$0.send`.
In order to fix it it should have called the send with apnsID parameter.

This is the real fix -> https://github.com/vapor/apns/pull/26

When using `vapor/apns` and `kylebrowning/APNSwift` in master it worked as expecte, no infinite recursion.
```swift
    .package(url: "https://github.com/vapor/apns.git", .branch("master")),
    .package(url: "https://github.com/kylebrowning/APNSwift.git", .branch("master")),
```

When using `vapor/apns` 1.0.0 and `kylebrowning/APNSwift` in master it had the infinite recursion issue.
```swift
    .package(url: "https://github.com/vapor/apns.git", from: "1.0.0"),
    .package(url: "https://github.com/kylebrowning/APNSwift.git", .branch("master")),
```

When using `vapor/apns` 1.0.0 with the default version of `kylebrowning/APNSwift` 2.1.0 in master it worked as expected, no infinite recursion.
```swift
    .package(url: "https://github.com/vapor/apns.git", from: "1.0.0"),
```

When vapor/apns will update to 1.1.0 and `kylebrowning/APNSwift` to 2.2.0 the issue will not exist anymore.