### PR TITLE
Make connection pool public

### DIFF
--- a/Sources/APNS/APNSConnectionSource.swift
+++ b/Sources/APNS/APNSConnectionSource.swift
@@ -1,7 +1,7 @@
 import AsyncKit
 import Logging
 
-internal final class APNSConnectionSource: ConnectionPoolSource {
+public final class APNSConnectionSource: ConnectionPoolSource {
     private let configuration: APNSwiftConfiguration
 
     public init(configuration: APNSwiftConfiguration) {

--- a/Sources/APNS/Application+APNS.swift
+++ b/Sources/APNS/Application+APNS.swift
@@ -24,7 +24,7 @@ extension Application {
             typealias Value = EventLoopGroupConnectionPool<APNSConnectionSource>
         }
 
-        internal var pool: EventLoopGroupConnectionPool<APNSConnectionSource> {
+        public var pool: EventLoopGroupConnectionPool<APNSConnectionSource> {
             if let existing = self.application.storage[PoolKey.self] {
                 return existing
             } else {


### PR DESCRIPTION
This PR makes the connection pool public. This allows us to create a `APNS` object for `QueueContext` for example and supply the correct logger and event loop, instead of being forced to use `.hop(to:)` and using the request logger or application logger.