### PR TITLE
Support APNSwift 7.0.1 and modernise the package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,29 @@ concurrency:
 on:
   pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
   push: { branches: [ main ] }
+permissions:
+  contents: read
 
 jobs:
   unit-tests:
+    permissions:
+      contents: read
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
     with:
       with_coverage: true
       with_tsan: false
+      with_linting: true
+      with_musl: true
+      with_android: false
+      with_windows: false
+      with_wasm: false
+      ios_scheme_name: vapor-apns
+      ios_xcodebuild_action: ""
+    secrets: inherit
 
+  submit-dependencies:
+    permissions:
+      contents: write
+    if: ${{ github.event_name == 'push' }}
+    uses: vapor/ci/.github/workflows/submit-deps.yml@main
+    secrets: inherit

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,70 @@
+{
+  "fileScopedDeclarationPrivacy": {
+    "accessLevel": "private"
+  },
+  "indentation": {
+    "spaces": 4
+  },
+  "indentConditionalCompilationBlocks": true,
+  "indentSwitchCaseLabels": false,
+  "lineBreakAroundMultilineExpressionChainComponents": false,
+  "lineBreakBeforeControlFlowKeywords": false,
+  "lineBreakBeforeEachArgument": false,
+  "lineBreakBeforeEachGenericRequirement": false,
+  "lineLength": 140,
+  "maximumBlankLines": 1,
+  "multiElementCollectionTrailingCommas": true,
+  "noAssignmentInExpressions": {
+    "allowedFunctions": [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "prioritizeKeepingFunctionOutputTogether": false,
+  "respectsExistingLineBreaks": true,
+  "rules": {
+    "AllPublicDeclarationsHaveDocumentation": false,
+    "AlwaysUseLiteralForEmptyCollectionInit": false,
+    "AlwaysUseLowerCamelCase": true,
+    "AmbiguousTrailingClosureOverload": true,
+    "BeginDocumentationCommentWithOneLineSummary": false,
+    "DoNotUseSemicolons": true,
+    "DontRepeatTypeInStaticProperties": true,
+    "FileScopedDeclarationPrivacy": true,
+    "FullyIndirectEnum": true,
+    "GroupNumericLiterals": true,
+    "IdentifiersMustBeASCII": true,
+    "NeverForceUnwrap": false,
+    "NeverUseForceTry": false,
+    "NeverUseImplicitlyUnwrappedOptionals": false,
+    "NoAccessLevelOnExtensionDeclaration": true,
+    "NoAssignmentInExpressions": true,
+    "NoBlockComments": true,
+    "NoCasesWithOnlyFallthrough": true,
+    "NoEmptyTrailingClosureParentheses": true,
+    "NoLabelsInCasePatterns": true,
+    "NoLeadingUnderscores": false,
+    "NoParensAroundConditions": true,
+    "NoPlaygroundLiterals": true,
+    "NoVoidReturnOnFunctionSignature": true,
+    "OmitExplicitReturns": false,
+    "OneCasePerLine": true,
+    "OneVariableDeclarationPerLine": true,
+    "OnlyOneTrailingClosureArgument": true,
+    "OrderedImports": true,
+    "ReplaceForEachWithForLoop": true,
+    "ReturnVoidInsteadOfEmptyTuple": true,
+    "TypeNamesShouldBeCapitalized": true,
+    "UseEarlyExits": false,
+    "UseExplicitNilCheckInConditions": true,
+    "UseLetInEveryBoundCaseVariable": true,
+    "UseShorthandTypeNames": true,
+    "UseSingleLinePropertyGetter": true,
+    "UseSynthesizedInitializer": true,
+    "UseTripleSlashForDocumentationComments": true,
+    "UseWhereClausesInForLoops": false,
+    "ValidateDocumentationComments": false
+  },
+  "spacesAroundRangeFormationOperators": false,
+  "tabWidth": 4,
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "VaporAPNS", targets: ["VaporAPNS"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server-community/APNSwift.git", from: "7.0.0"),
+        .package(url: "https://github.com/swift-server-community/APNSwift.git", from: "7.0.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.110.1"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     .library(name: "VaporAPNS", targets: ["VaporAPNS"])
   ],
   dependencies: [
-    .package(url: "https://github.com/swift-server-community/APNSwift.git", from: "6.1.0"),
+    .package(url: "https://github.com/swift-server-community/APNSwift.git", from: "7.0.0"),
     .package(url: "https://github.com/vapor/vapor.git", from: "4.110.1"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,31 +1,56 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(
-  name: "vapor-apns",
-  platforms: [
-    .macOS(.v13),
-    .iOS(.v16),
-  ],
-  products: [
-    .library(name: "VaporAPNS", targets: ["VaporAPNS"])
-  ],
-  dependencies: [
-    .package(url: "https://github.com/swift-server-community/APNSwift.git", from: "7.0.0"),
-    .package(url: "https://github.com/vapor/vapor.git", from: "4.110.1"),
-  ],
-  targets: [
-    .target(
-      name: "VaporAPNS",
-      dependencies: [
-        .product(name: "APNS", package: "apnswift"),
-        .product(name: "Vapor", package: "vapor"),
-      ]),
-    .testTarget(
-      name: "VaporAPNSTests",
-      dependencies: [
-        .target(name: "VaporAPNS"),
-        .product(name: "VaporTesting", package: "vapor"),
-      ]),
-  ]
+    name: "vapor-apns",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16),
+        .tvOS(.v16),
+        .watchOS(.v9),
+    ],
+    products: [
+        .library(name: "VaporAPNS", targets: ["VaporAPNS"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swift-server-community/APNSwift.git", from: "7.0.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.110.1"),
+    ],
+    targets: [
+        .target(
+            name: "VaporAPNS",
+            dependencies: [
+                .product(name: "APNS", package: "apnswift"),
+                .product(name: "APNSCore", package: "apnswift"),
+                .product(name: "Vapor", package: "vapor"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .testTarget(
+            name: "VaporAPNSTests",
+            dependencies: [
+                .target(name: "VaporAPNS"),
+                .product(name: "APNSCore", package: "apnswift"),
+                .product(name: "VaporTesting", package: "vapor"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+    ]
 )
+
+var swiftSettings: [SwiftSetting] {
+    [
+        .treatAllWarnings(as: .error),
+        .strictMemorySafety(),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault"),
+        .enableUpcomingFeature("MemberImportVisibility"),
+        .enableUpcomingFeature("InferIsolatedConformances"),
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+        .enableUpcomingFeature("ImmutableWeakCaptures"),
+        .enableExperimentalFeature("SuppressedAssociatedTypesWithDefaults"),
+        .enableExperimentalFeature("LifetimeDependence"),
+        .enableExperimentalFeature("Lifetimes"),
+        .enableUpcomingFeature("LifetimeDependence"),
+    ]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "VaporAPNS", targets: ["VaporAPNS"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server-community/APNSwift.git", from: "7.0.1"),
+        .package(url: "https://github.com/kylebrowning/APNSwift.git", from: "7.0.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.110.1"),
     ],
     targets: [

--- a/Sources/VaporAPNS/APNSContainerID.swift
+++ b/Sources/VaporAPNS/APNSContainerID.swift
@@ -1,4 +1,3 @@
-
 extension APNSContainers.ID {
     /// A default container ID available for use.
     ///
@@ -9,14 +8,14 @@ extension APNSContainers.ID {
     public static var `default`: APNSContainers.ID {
         return .init(string: "default")
     }
-    
+
     /// An ID that can be used for the production APNs environment.
     ///
     /// - Note: You must configure this ID before using it by calling ``APNSContainers/use(_:eventLoopGroupProvider:responseDecoder:requestEncoder:byteBufferAllocator:as:isDefault:)``
     public static var production: APNSContainers.ID {
         return .init(string: "production")
     }
-    
+
     /// An ID that can be used for the development (aka sandbox) APNs environment.
     ///
     /// - Note: You must configure this ID before using it by calling ``APNSContainers/use(_:eventLoopGroupProvider:responseDecoder:requestEncoder:byteBufferAllocator:as:isDefault:)``

--- a/Sources/VaporAPNS/APNSContainers.swift
+++ b/Sources/VaporAPNS/APNSContainers.swift
@@ -1,15 +1,8 @@
 public import APNS
+public import Foundation
 import Logging
 public import NIOCore
 import Vapor
-
-#if canImport(Darwin)
-    public import Foundation
-#else
-    // JSONEncoder / JSONDecoder is not Sendable in scf, but is in Darwin...
-    // Import as `@preconcurrency` to fix warnings.
-    @preconcurrency public import Foundation
-#endif
 
 public typealias APNSGenericClient = APNSClient<JSONDecoder, JSONEncoder>
 

--- a/Sources/VaporAPNS/APNSContainers.swift
+++ b/Sources/VaporAPNS/APNSContainers.swift
@@ -69,7 +69,7 @@ extension APNSContainers {
     ///
     /// let productionConfig = APNSClientConfiguration(
     ///     authenticationMethod: .jwt(
-    ///         privateKey: try .loadFrom(string: apnsKey),
+    ///         privateKey: try .init(pemRepresentation: apnsKey),
     ///         keyIdentifier: keyIdentifier,
     ///         teamIdentifier: teamIdentifier
     ///     ),
@@ -85,7 +85,7 @@ extension APNSContainers {
     /// )
     ///
     /// var developmentConfig = productionConfig
-    /// developmentConfig.environment = .sandbox
+    /// developmentConfig.environment = .development
     ///
     /// app.apns.containers.use(
     ///     developmentConfig,

--- a/Sources/VaporAPNS/APNSContainers.swift
+++ b/Sources/VaporAPNS/APNSContainers.swift
@@ -1,15 +1,15 @@
-import Vapor
-import APNS
+public import APNS
 import Logging
+public import NIOCore
+import Vapor
+
 #if canImport(Darwin)
-import Foundation
+    public import Foundation
 #else
-// JSONEncoder / JSONDecoder is not Sendable in scf, but is in Darwin...
-// Import as `@preconcurrency` to fix warnings.
-@preconcurrency import Foundation
+    // JSONEncoder / JSONDecoder is not Sendable in scf, but is in Darwin...
+    // Import as `@preconcurrency` to fix warnings.
+    @preconcurrency public import Foundation
 #endif
-import NIO
-import NIOConcurrencyHelpers
 
 public typealias APNSGenericClient = APNSClient<JSONDecoder, JSONEncoder>
 
@@ -24,7 +24,7 @@ public final actor APNSContainers: Sendable {
     public final class Container: Sendable {
         public let configuration: APNSClientConfiguration
         public let client: APNSGenericClient
-        
+
         internal init(configuration: APNSClientConfiguration, client: APNSGenericClient) {
             self.configuration = configuration
             self.client = client
@@ -36,7 +36,7 @@ public final actor APNSContainers: Sendable {
     private let logger: Logger
 
     init() {
-        self.containers =  [:]
+        self.containers = [:]
         self.defaultID = nil
         self.logger = Logger(label: "codes.vapor.apns.containers")
     }
@@ -107,7 +107,7 @@ extension APNSContainers {
     ///     case development
     /// }
     ///
-    /// /// Get the APNs environment from the embedded 
+    /// /// Get the APNs environment from the embedded
     /// /// provisioning profile, or nil if it can't
     /// /// be determined.
     /// ///
@@ -186,7 +186,7 @@ extension APNSContainers {
                 byteBufferAllocator: byteBufferAllocator
             )
         )
-        
+
         if isDefault == true || (self.defaultID == nil && isDefault != false) {
             self.defaultID = id
         }

--- a/Sources/VaporAPNS/Application+APNS.swift
+++ b/Sources/VaporAPNS/Application+APNS.swift
@@ -63,7 +63,7 @@ extension Application.APNS {
     /// else { throw Abort(.serviceUnavailable) }
     /// 
     /// app.apns.configure(.jwt(
-    ///     privateKey: try .loadFrom(string: apnsKey),
+    ///     privateKey: try .init(pemRepresentation: apnsKey),
     ///     /// The identifier of the key in the developer portal.
     ///     keyIdentifier: Environment.get("APNS_KEY_ID"),
     ///     /// The team identifier of the app in the developer portal.

--- a/Sources/VaporAPNS/Application+APNS.swift
+++ b/Sources/VaporAPNS/Application+APNS.swift
@@ -1,5 +1,7 @@
-import APNS
-import Vapor
+public import APNS
+import APNSCore
+import Foundation
+public import Vapor
 
 extension Application {
     public var apns: APNS {
@@ -54,14 +56,14 @@ extension Application {
 
 extension Application.APNS {
     /// Configure both a production and development APNs environment.
-    /// 
+    ///
     /// This convenience method creates two clients available via ``client(_:)`` with ``APNSContainers/ID/production`` and ``APNSContainers/ID/development`` that make it easy to support both development builds (ie. run from Xcode) and release builds (ie. TestFlight/App Store):
-    /// 
+    ///
     /// ```swift
     /// /// The .p8 file as a string.
     /// guard let apnsKey = Environment.get("APNS_KEY_P8")
     /// else { throw Abort(.serviceUnavailable) }
-    /// 
+    ///
     /// app.apns.configure(.jwt(
     ///     privateKey: try .init(pemRepresentation: apnsKey),
     ///     /// The identifier of the key in the developer portal.
@@ -69,9 +71,9 @@ extension Application.APNS {
     ///     /// The team identifier of the app in the developer portal.
     ///     teamIdentifier: Environment.get("APNS_TEAM_ID")
     /// ))
-    /// 
+    ///
     /// // ...
-    /// 
+    ///
     /// let response = switch deviceToken.environment {
     /// case .production:
     ///     try await apns.client(.production)
@@ -81,11 +83,11 @@ extension Application.APNS {
     ///         .sendAlertNotification(notification, deviceToken: deviceToken.hexadecimalToken)
     /// }
     /// ```
-    /// 
+    ///
     /// For more control over configuration, including sample code to determine the environment an APFs device token belongs to, see ``APNSContainers/use(_:eventLoopGroupProvider:responseDecoder:requestEncoder:byteBufferAllocator:as:isDefault:)``.
     ///
     /// - Note: The same key can be used for both the development and production environments.
-    /// 
+    ///
     /// - Important: Make sure not to store your APNs key within your code or repo directly, and opt to store it via a secure store specific to your deployment, such as in a .env supplied at deploy time.
     ///
     /// - Parameter authenticationMethod: An APNs authentication method to use when connecting to Apple's production and development servers.
@@ -100,7 +102,7 @@ extension Application.APNS {
             requestEncoder: JSONEncoder(),
             as: .production
         )
-        
+
         await containers.use(
             APNSClientConfiguration(
                 authenticationMethod: authenticationMethod,

--- a/Sources/VaporAPNS/Request+APNS.swift
+++ b/Sources/VaporAPNS/Request+APNS.swift
@@ -1,5 +1,4 @@
-import APNS
-import Vapor
+public import Vapor
 
 extension Request {
     public var apns: Application.APNS {

--- a/Tests/VaporAPNSTests/APNSTests.swift
+++ b/Tests/VaporAPNSTests/APNSTests.swift
@@ -1,30 +1,11 @@
 import APNS
-import VaporAPNS
+import APNSCore
 import Testing
 import Vapor
+import VaporAPNS
 import VaporTesting
 
 private struct Payload: Codable {}
-
-private let appleECP8PrivateKey = """
------BEGIN PRIVATE KEY-----
-MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg2sD+kukkA8GZUpmm
-jRa4fJ9Xa/JnIG4Hpi7tNO66+OGgCgYIKoZIzj0DAQehRANCAATZp0yt0btpR9kf
-ntp4oUUzTV0+eTELXxJxFvhnqmgwGAm1iVW132XLrdRG/ntlbQ1yzUuJkHtYBNve
-y+77Vzsd
------END PRIVATE KEY-----
-"""
-
-private func withApp<T>(_ test: (Application) async throws -> T) async throws -> T {
-    let app = try await Application.make(.testing)
-    defer {
-        Task {
-            await app.apns.containers.shutdown()
-            try await app.asyncShutdown()
-        }
-    }
-    return try await test(app)
-}
 
 @Test("Application")
 func testApplication() async throws {
@@ -62,7 +43,7 @@ func testApplication() async throws {
             )
             return .ok
         }
-        
+
         try await app.testing().test(.GET, "test-push") { response async in
             #expect(response.status == .internalServerError)
         }
@@ -93,13 +74,13 @@ func testContainers() async throws {
         )
 
         let defaultContainer = await app.apns.containers.container()
-        
+
         #expect(defaultContainer != nil)
-        
+
         let defaultMethodContainer = await app.apns.containers.container(for: .default)!
-        
+
         let defaultComputedContainer = await app.apns.containers.container!
-        
+
         #expect(defaultContainer === defaultMethodContainer)
         #expect(defaultContainer === defaultComputedContainer)
 
@@ -109,7 +90,7 @@ func testContainers() async throws {
 
             return .ok
         }
-        
+
         try await app.testing().test(.GET, "test-push") { response async in
             #expect(response.status == .ok)
         }
@@ -128,15 +109,15 @@ func testContainers() async throws {
         )
 
         let containerPostCustom = await app.apns.containers.container()
-        
+
         #expect(containerPostCustom != nil)
-        
+
         app.get("test-push2") { req -> HTTPStatus in
             let client = await req.apns.client
             #expect(client === containerPostCustom?.client)
             return .ok
         }
-        
+
         try await app.testing().test(.GET, "test-push2") { response async in
             #expect(response.status == .ok)
         }
@@ -181,16 +162,16 @@ func testCustomContainers() async throws {
         )
 
         let containerPostCustom = await app.apns.containers.container()
-        
+
         #expect(containerPostCustom != nil)
-        
+
         app.get("test-push2") { req -> HTTPStatus in
             let client = await req.apns.client
             #expect(client === containerPostCustom?.client)
-            
+
             return .ok
         }
-        
+
         try await app.testing().test(.GET, "test-push2") { response async in
             #expect(response.status == .ok)
         }
@@ -234,21 +215,21 @@ func testNonDefaultContainers() async throws {
         )
 
         let containerPostCustom = await app.apns.containers.container()
-        
+
         let containerNonDefaultCustom = await app.apns.containers.container(for: .custom)
-        
+
         let customContainer = await app.apns.containers.container(for: .custom)
-        
+
         #expect(customContainer !== containerPostCustom)
         #expect(containerPostCustom != nil)
-        
+
         app.get("test-push2") { req -> HTTPStatus in
             let customClient = await req.apns.client(.custom)
             #expect(customClient !== containerPostCustom?.client)
             #expect(customClient === containerNonDefaultCustom?.client)
             return .ok
         }
-        
+
         try await app.testing().test(.GET, "test-push2") { response async in
             #expect(response.status == .ok)
         }

--- a/Tests/VaporAPNSTests/MockAPNSServerTests.swift
+++ b/Tests/VaporAPNSTests/MockAPNSServerTests.swift
@@ -1,32 +1,14 @@
 import APNS
-import VaporAPNS
-import Testing
-import Vapor
-import VaporTesting
+import APNSCore
 import NIOCore
 import NIOPosix
+import Testing
+import Vapor
+import VaporAPNS
+import VaporTesting
 
 private struct Payload: Codable {
     let message: String
-}
-
-private let appleECP8PrivateKey = """
------BEGIN PRIVATE KEY-----
-MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg2sD+kukkA8GZUpmm
-jRa4fJ9Xa/JnIG4Hpi7tNO66+OGgCgYIKoZIzj0DAQehRANCAATZp0yt0btpR9kf
-ntp4oUUzTV0+eTELXxJxFvhnqmgwGAm1iVW132XLrdRG/ntlbQ1yzUuJkHtYBNve
-y+77Vzsd
------END PRIVATE KEY-----
-"""
-
-private func withApp<T>(_ test: (Application) async throws -> T) async throws -> T {
-    let app = try await Application.make(.testing)
-    defer {
-        Task {
-            try await app.asyncShutdown()
-        }
-    }
-    return try await test(app)
 }
 
 @Test("APNS Container Configuration")
@@ -40,7 +22,7 @@ func testAPNSContainerConfiguration() async throws {
             ),
             environment: .development
         )
-        
+
         await app.apns.containers.use(
             apnsConfig,
             eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton),
@@ -48,7 +30,7 @@ func testAPNSContainerConfiguration() async throws {
             requestEncoder: JSONEncoder(),
             as: .default
         )
-        
+
         // Verify that the container is configured
         let container = await app.apns.containers.container()
         #expect(container != nil)
@@ -69,7 +51,7 @@ func testAPNSClientAccessFromRequest() async throws {
             ),
             environment: .development
         )
-        
+
         await app.apns.containers.use(
             apnsConfig,
             eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton),
@@ -77,14 +59,14 @@ func testAPNSClientAccessFromRequest() async throws {
             requestEncoder: JSONEncoder(),
             as: .default
         )
-        
+
         // Test that we can access APNS client from request
         app.get("test-apns-access") { req async -> HTTPStatus in
             let container = await req.application.apns.containers.container()
             #expect(container != nil)
             return .ok
         }
-        
+
         try await app.testing().test(.GET, "test-apns-access") { response async in
             #expect(response.status == .ok)
         }
@@ -103,7 +85,7 @@ func testMultipleAPNSContainers() async throws {
             ),
             environment: .production
         )
-        
+
         let developmentConfig = APNSClientConfiguration(
             authenticationMethod: .jwt(
                 privateKey: try .init(pemRepresentation: appleECP8PrivateKey),
@@ -112,7 +94,7 @@ func testMultipleAPNSContainers() async throws {
             ),
             environment: .development
         )
-        
+
         await app.apns.containers.use(
             productionConfig,
             eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton),
@@ -120,7 +102,7 @@ func testMultipleAPNSContainers() async throws {
             requestEncoder: JSONEncoder(),
             as: .production
         )
-        
+
         await app.apns.containers.use(
             developmentConfig,
             eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton),
@@ -128,11 +110,11 @@ func testMultipleAPNSContainers() async throws {
             requestEncoder: JSONEncoder(),
             as: .development
         )
-        
+
         // Verify both containers are configured
         let productionContainer = await app.apns.containers.container(for: .production)
         let developmentContainer = await app.apns.containers.container(for: .development)
-        
+
         #expect(productionContainer != nil)
         #expect(developmentContainer != nil)
         #expect(productionContainer?.configuration != nil)
@@ -152,7 +134,7 @@ func testAPNSContainerShutdown() async throws {
             ),
             environment: .development
         )
-        
+
         await app.apns.containers.use(
             apnsConfig,
             eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton),
@@ -160,11 +142,11 @@ func testAPNSContainerShutdown() async throws {
             requestEncoder: JSONEncoder(),
             as: .default
         )
-        
+
         // Verify container is configured
         let container = await app.apns.containers.container()
         #expect(container != nil)
-        
+
         // Test shutdown - this should not throw
         await app.apns.containers.shutdown()
     }
@@ -174,16 +156,17 @@ func testAPNSContainerShutdown() async throws {
 func testConvenienceConfigurationMethod() async throws {
     try await withApp { app in
         // Test the convenience configure method that sets up both production and development
-        await app.apns.configure(.jwt(
-            privateKey: try .init(pemRepresentation: appleECP8PrivateKey),
-            keyIdentifier: "9UC9ZLQ8YW",
-            teamIdentifier: "ABBM6U9RM5"
-        ))
-        
+        await app.apns.configure(
+            .jwt(
+                privateKey: try .init(pemRepresentation: appleECP8PrivateKey),
+                keyIdentifier: "9UC9ZLQ8YW",
+                teamIdentifier: "ABBM6U9RM5"
+            ))
+
         // Verify both containers are configured
         let productionContainer = await app.apns.containers.container(for: .production)
         let developmentContainer = await app.apns.containers.container(for: .development)
-        
+
         #expect(productionContainer != nil)
         #expect(developmentContainer != nil)
         #expect(productionContainer?.configuration != nil)
@@ -200,9 +183,9 @@ func testRequestAPNSProperty() async throws {
             // Note: application property is internal, so just verify apns exists
             return .ok
         }
-        
+
         try await app.testing().test(.GET, "test-request-apns") { response async in
             #expect(response.status == .ok)
         }
     }
-} 
+}

--- a/Tests/VaporAPNSTests/TestUtilities.swift
+++ b/Tests/VaporAPNSTests/TestUtilities.swift
@@ -1,0 +1,28 @@
+import Vapor
+
+/// A throwaway EC P-256 key used purely to satisfy JWT configuration in tests.
+///
+/// It is not registered with Apple and cannot authenticate against APNs.
+let appleECP8PrivateKey = """
+    -----BEGIN PRIVATE KEY-----
+    MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg2sD+kukkA8GZUpmm
+    jRa4fJ9Xa/JnIG4Hpi7tNO66+OGgCgYIKoZIzj0DAQehRANCAATZp0yt0btpR9kf
+    ntp4oUUzTV0+eTELXxJxFvhnqmgwGAm1iVW132XLrdRG/ntlbQ1yzUuJkHtYBNve
+    y+77Vzsd
+    -----END PRIVATE KEY-----
+    """
+
+/// Runs `test` against a freshly made testing `Application`, shutting it down afterwards.
+///
+/// The shutdown is awaited rather than fired off in a detached `Task` so that APNs containers
+/// are torn down before the test returns.
+func withApp(_ test: (Application) async throws -> Void) async throws {
+    let app = try await Application.make(.testing)
+    do {
+        try await test(app)
+    } catch {
+        try await app.asyncShutdown()
+        throw error
+    }
+    try await app.asyncShutdown()
+}


### PR DESCRIPTION
### Motivation

VaporAPNS was capped at APNSwift 6.x, and the package predated the current Vapor tooling baseline.

### Modifications

- Require APNSwift 7.0.1, which links FoundationEssentials rather than full Foundation.
- Raise the manifest to Swift tools 6.2 with the standard Vapor swift settings; declare tvOS 16 and watchOS 9.
- Consolidate the test helpers into `TestUtilities.swift` and await application shutdown rather than racing it in a detached `Task`.
- Enable linting, musl and iOS in CI; add dependency submission and the shared `.swift-format` config.

### Result

Builds and tests pass on macOS, Linux (6.2 and 6.3), musl and iOS.

`api-breakage` reports four `nonisolated` changes on `Application.APNS` from `NonisolatedNonsendingByDefault`. Intended, and why this warrants a major release.
